### PR TITLE
Allow configuration of client frame masking.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,12 @@ impl WebSocketUpgrade {
         self
     }
 
+    /// Set true to accept unmasked frames from clients (defaults to false)
+    pub fn accept_unmasked_frames(mut self, accept: bool) -> Self {
+        self.config.accept_unmasked_frames = accept;
+        self
+    }
+
     /// Set the known protocols.
     ///
     /// If the protocol name specified by `Sec-WebSocket-Protocol` header


### PR DESCRIPTION
Carries the configuration of client side frame masking from Tungstenite's configuration object through to the WebSocketUpgrade.