### PR TITLE
bump dependency versions and fix removed lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **changed:** Replaced usage of removed lint
 
 # 0.3.0 (02. August, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- **changed:** Update axum to 0.7, necessitating updating axum-core to 0.4, and http to 1.0 ([#12])
 - **changed:** Replaced usage of removed lint
 
 # 0.3.0 (02. August, 2022)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- **changed:** Update tokio-tungstenite to 0.21
 - **changed:** Update axum to 0.7, necessitating updating axum-core to 0.4, and http to 1.0 ([#12])
 - **changed:** Replaced usage of removed lint
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ repository = "https://github.com/davidpdrsn/axum-tungstenite"
 
 [dependencies]
 async-trait = "0.1.59"
-axum-core = "0.3.0"
+axum-core = "0.4.0"
 base64 = "0.21.0"
 bytes = "1.3.0"
 futures-util = { version = "0.3.25", default-features = false, features = ["alloc"] }
-http = "0.2.8"
+http = "1.0.0"
 http-body = "0.4.5"
 hyper = "0.14.23"
 sha-1 = "0.10.1"
@@ -24,4 +24,4 @@ tokio = { version = "1.23.0", features = ["rt"] }
 tokio-tungstenite = "0.20.0"
 
 [dev-dependencies]
-axum = "0.6.1"
+axum = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ http-body = "0.4.5"
 hyper = "0.14.23"
 sha-1 = "0.10.1"
 tokio = { version = "1.23.0", features = ["rt"] }
-tokio-tungstenite = "0.20.0"
+tokio-tungstenite = "0.21.0"
 
 [dev-dependencies]
 axum = "0.7.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@
     missing_debug_implementations,
     missing_docs
 )]
-#![deny(unreachable_pub, private_in_public)]
+#![deny(unreachable_pub, private_interfaces, private_bounds)]
 #![allow(elided_lifetimes_in_paths, clippy::type_complexity)]
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg))]


### PR DESCRIPTION
- Update tokio-tungstenite to 0.21
- Update axum to 0.7, necessitating updating axum-core to 0.4, and http to 1.0 (#12)
- Replaced usage of removed lint

Fixes #12
Bumped tokio-tungstenite and replaced removed lint while I was at it since it made sense.