### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ bytes = "1.3.0"
 futures-util = { version = "0.3.25", default-features = false, features = ["alloc"] }
 http = "1.0.0"
 http-body = "1.0.0"
-hyper = { version = "1.0.0", features = ["full"] }
+hyper = "1.0.0"
 hyper-util = { version = "0.1.3", features = ["tokio"] }
 sha-1 = "0.10.1"
 tokio = { version = "1.23.0", features = ["rt"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-tungstenite"
-version = "0.3.0"
+version = "0.4.0"
 categories = ["asynchronous", "network-programming", "web-programming"]
 description = "WebSocket connections for axum directly using tungstenite"
 edition = "2021"
@@ -12,16 +12,17 @@ repository = "https://github.com/davidpdrsn/axum-tungstenite"
 
 [dependencies]
 async-trait = "0.1.59"
-axum-core = "0.3.0"
-base64 = "0.21.0"
+axum-core = "0.4.0"
+base64 = "0.22.0"
 bytes = "1.3.0"
 futures-util = { version = "0.3.25", default-features = false, features = ["alloc"] }
-http = "0.2.8"
-http-body = "0.4.5"
-hyper = "0.14.23"
+http = "1.0.0"
+http-body = "1.0.0"
+hyper = { version = "1.0.0", features = ["full"] }
+hyper-util = { version = "0.1.3", features = ["tokio"] }
 sha-1 = "0.10.1"
 tokio = { version = "1.23.0", features = ["rt"] }
-tokio-tungstenite = "0.20.0"
+tokio-tungstenite = "0.21.0"
 
 [dev-dependencies]
-axum = "0.6.1"
+axum = "0.7.0"


### PR DESCRIPTION
Hey, 
I was trying to use this crate, and it was hard, because the current version of axum uses incompatible versions of hyper, http and tokio-tungstenite. So I updated the versions in the Cargo.toml.

Hyper chose to implement their own async read and write traits now, and provides an adapter to the tokio versions in the hyper-utils crate. Using this adapter requires wrapping `Upgraded` in a `TokioIo` which is a type change to the public API, so I decided to increase the version to 0.4.0 instead of 0.3.1.